### PR TITLE
Add repository metadata automatically to META.yml

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,6 +6,8 @@ version = 0.065
 
 [@ROKR]
 
+[GithubMeta]
+
 [ExecDir]
 
 [Prereqs / TestRequires]


### PR DESCRIPTION
This change adds the GithubMeta Dist::Zilla plugin to the distribution's
Dist::Zilla configuration so that information about the dist's repository
will be automatically added to its META.yml output.  This information then
helps services such as MetaCPAN display repository information about the
distribution, and removes a CPANTS warning about missing repository
information.
