### PR TITLE
Ignore Dist::Zilla's .build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Config-JFDI-*
 Makefile
 inc
 local
+.build


### PR DESCRIPTION
... now the directory doesn't unnecessarily turn up in `git status` output.
