### PR TITLE
Ignore the .build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.build/
 Config-JFDI-*
 Makefile
 inc


### PR DESCRIPTION
This stops the `.build` directory from turning up in `git status` output
unnecessarily.
