### PR TITLE
Add initial Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: false
+
+language: perl
+
+perl:
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+    - "5.8"
+
+install:
+    - cpanm Dist::Zilla
+    - cpanm Moose::Autobox
+    - cpanm Dist::Zilla::PluginBundle::ROKR || { cat ~/.cpanm/build.log ; false ; }
+    - dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+    - dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+
+script:
+    - dzil test --author --release

--- a/dist.ini
+++ b/dist.ini
@@ -8,9 +8,11 @@ version = 0.065
 
 [ExecDir]
 
+[ReadmeFromPod]
+
 [Prereqs / TestRequires]
 Test::Most = 0
- 
+
 [Prereqs]
 Getopt::Usaginator = 0
 Carp::Clan::Share = 0


### PR DESCRIPTION
[Travis-CI](https://travis-ci.org) is a free (for open source projects) continuous integration system.  This PR adds an initial configuration for this service so that future changes to the module can be automatically tested under various Perl versions.  Any questions or comments regarding this PR are more than welcome!  This PR is submitted in the hope that it is useful; if anything needs to be changed or updated, please just let me know and I'll resubmit as appropriate.

It turns out that `Moose::Autobox` is an implicit dependency for the ROKR
`Dist::Zilla` plugin bundle and needed to be installed before the ROKR
bundle.

The `ReadmeFromPod` `Dist::Zilla` plugin was also found to be an implicit
dependency which wasn't later picked up by `dzil authordeps --missing` and
hence has been added to `dist.ini` in order to be installed by the above
command.

The dependencies install successfully and the test suite passes in this
configuration.
